### PR TITLE
Error constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shaken-qr-reader",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "QR code reader for Japanese automobile certification",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/container/qrCodeContainer.ts
+++ b/src/container/qrCodeContainer.ts
@@ -3,8 +3,8 @@ import QRCodeContainerBase from './qrCodeContainerBase'
 import Certificate from '../data/certificate/certificate'
 import KeiCertificate from '../data/certificate/keiCertificate'
 import { InvalidQRCode, ReadQRCode } from '../types'
-import Payload21 from "../data/payload/normal/payload21";
-import Payload22 from "../data/payload/normal/payload22";
+import Payload21 from '../data/payload/normal/payload21'
+import Payload22 from '../data/payload/normal/payload22'
 
 const firstQRIndexes = [1, 2, 3]
 const secondQRIndexes = [4, 5]

--- a/src/container/qrCodeContainerKei.ts
+++ b/src/container/qrCodeContainerKei.ts
@@ -1,13 +1,13 @@
-import {QRCode} from 'jsqr'
+import { QRCode } from 'jsqr'
 import QRCodeContainerBase from './qrCodeContainerBase'
 import KeiCertificate from '../data/certificate/keiCertificate'
 import Certificate from '../data/certificate/certificate'
-import {InvalidQRCode, ReadQRCode} from '../types'
-import Payload22 from "../data/payload/kei/payload22";
-import Payload31 from "../data/payload/kei/payload31";
-import Payload51 from "../data/payload/kei/payload51";
-import Payload61 from "../data/payload/kei/payload61";
-import Payload71 from "../data/payload/kei/payload71";
+import { InvalidQRCode, ReadQRCode } from '../types'
+import Payload22 from '../data/payload/kei/payload22'
+import Payload31 from '../data/payload/kei/payload31'
+import Payload51 from '../data/payload/kei/payload51'
+import Payload61 from '../data/payload/kei/payload61'
+import Payload71 from '../data/payload/kei/payload71'
 
 const qrTypeVersions = ['71', '61', '51', '31', '22']
 

--- a/src/container/qrCodeContainerKeiOld.ts
+++ b/src/container/qrCodeContainerKeiOld.ts
@@ -1,11 +1,11 @@
-import {QRCode} from 'jsqr'
+import { QRCode } from 'jsqr'
 import QRCodeContainerBase from './qrCodeContainerBase'
 import KeiCertificate from '../data/certificate/keiCertificate'
 import Certificate from '../data/certificate/certificate'
-import {InvalidQRCode, ReadQRCode} from '../types'
-import Payload22 from "../data/payload/kei/payload22";
-import Payload31 from "../data/payload/kei/payload31";
-import KeiOldCertificate from "../data/certificate/keiOldCertificate";
+import { InvalidQRCode, ReadQRCode } from '../types'
+import Payload22 from '../data/payload/kei/payload22'
+import Payload31 from '../data/payload/kei/payload31'
+import KeiOldCertificate from '../data/certificate/keiOldCertificate'
 
 const qrTypeVersions = ['31', '22']
 
@@ -13,66 +13,66 @@ export default class QRCodeContainerKeiOld implements QRCodeContainerBase {
     qrCodes: QRCode[] = [];
 
     get missingIndex (): number[] {
-        return qrTypeVersions
-            .map(index => this.readQRTypeVersions.indexOf(index) === -1 ? qrTypeVersions.indexOf(index) + 1 : null)
-            .filter(index => index !== null)
+      return qrTypeVersions
+        .map(index => this.readQRTypeVersions.indexOf(index) === -1 ? qrTypeVersions.indexOf(index) + 1 : null)
+        .filter(index => index !== null)
     }
 
     get isCompleted (): boolean {
-        return this.missingIndex.length === 0
+      return this.missingIndex.length === 0
     }
 
     get result (): Certificate | KeiCertificate | null {
-        if (this.isCompleted) {
-            const payload22 = new Payload22(this.qrCodes.find((qrCode) => qrCode.data.split('/')[1] === '22'))
-            const payload31 = new Payload31(this.qrCodes.find((qrCode) => qrCode.data.split('/')[1] === '31'))
+      if (this.isCompleted) {
+        const payload22 = new Payload22(this.qrCodes.find((qrCode) => qrCode.data.split('/')[1] === '22'))
+        const payload31 = new Payload31(this.qrCodes.find((qrCode) => qrCode.data.split('/')[1] === '31'))
 
-            return new KeiOldCertificate(
-                payload31.carIdentifierLocation,
-                payload31.carTypeNumberAndCategoryNumber,
-                payload31.expiresAt,
-                payload31.registeredAt,
-                payload31.model,
-                payload31.frontFrontAxleWeight,
-                payload31.frontRearAxleWeight,
-                payload31.rearFrontAxleWeight,
-                payload31.rearRearAxleWeight,
-                payload31.noiseRegulation,
-                payload31.emissionNoiseRegulation,
-                payload31.driveSystem,
-                payload31.measuredOpacimeter,
-                payload31.measuredNoxAndPm,
-                payload31.nox,
-                payload31.pm,
-                '01',
-                payload22.number,
-                payload22.numberType,
-                payload22.identifier,
-                payload22.engineModel,
-                payload22.sheetType
-            )
-        }
+        return new KeiOldCertificate(
+          payload31.carIdentifierLocation,
+          payload31.carTypeNumberAndCategoryNumber,
+          payload31.expiresAt,
+          payload31.registeredAt,
+          payload31.model,
+          payload31.frontFrontAxleWeight,
+          payload31.frontRearAxleWeight,
+          payload31.rearFrontAxleWeight,
+          payload31.rearRearAxleWeight,
+          payload31.noiseRegulation,
+          payload31.emissionNoiseRegulation,
+          payload31.driveSystem,
+          payload31.measuredOpacimeter,
+          payload31.measuredNoxAndPm,
+          payload31.nox,
+          payload31.pm,
+          '01',
+          payload22.number,
+          payload22.numberType,
+          payload22.identifier,
+          payload22.engineModel,
+          payload22.sheetType
+        )
+      }
 
-        return null
+      return null
     }
 
     private get readQRTypeVersions (): string[] {
-        return this.qrCodes.map(qrCode => qrCode.data.split('/')[1])
+      return this.qrCodes.map(qrCode => qrCode.data.split('/')[1])
     }
 
     push = (qrCode: QRCode) => {
-        this.validate(qrCode)
+      this.validate(qrCode)
 
-        this.qrCodes.push(qrCode)
+      this.qrCodes.push(qrCode)
     }
 
     private validate = (qrCode: QRCode) => {
-        if (qrCode.data.split('/')[0] !== 'K') {
-            throw new InvalidQRCode('This is not a Kei QR code')
-        } else if (!qrTypeVersions.includes(qrCode.data.split('/')[1])) {
-            throw new InvalidQRCode('Cannot read this version of Kei QR code')
-        } else if (this.readQRTypeVersions.includes(qrCode.data.split('/')[1])) {
-            throw new ReadQRCode('This QR code is already read')
-        }
+      if (qrCode.data.split('/')[0] !== 'K') {
+        throw new InvalidQRCode('This is not a Kei QR code')
+      } else if (!qrTypeVersions.includes(qrCode.data.split('/')[1])) {
+        throw new InvalidQRCode('Cannot read this version of Kei QR code')
+      } else if (this.readQRTypeVersions.includes(qrCode.data.split('/')[1])) {
+        throw new ReadQRCode('This QR code is already read')
+      }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,16 @@
 export type CarType = 'normal' | 'kei' | 'kei_old'
 
-export class InvalidQRCode extends Error {}
-export class ReadQRCode extends Error {}
+export class InvalidQRCode extends Error {
+  constructor (e?: string) {
+    super(e)
+    this.name = new.target.name
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+export class ReadQRCode extends Error {
+  constructor (e?: string) {
+    super(e)
+    this.name = new.target.name
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}


### PR DESCRIPTION
v1.1.3 has the following problem.

```typescript
try {
          reader.push(image);
        } catch (e) {
          if (e instanceof ReadQRCode) { // This is not work. This is false if the reader scan an read QR code
            console.log('catch')
          } else if (e instanceof InvalidQRCode) { // This is not work. This is false if the reader scan invalid QR code.
            console.log('catch')
          } else {
            throw e // Run always.
          }
        }
```

The custormize error can be separated by using `instanceof` if this PR is merged.